### PR TITLE
docs: fix link to vLib Lua Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,27 @@ vLib tries to stay as close as possible to the Renoise Viewbuilder API. This is 
 
 If you are not familiar with that API, it's highly recommended to study some [Viewbuilder examples](https://github.com/renoise/xrnx/tree/master/Tools/com.renoise.ExampleToolGui.xrnx) first. However, if you are familiar with the Viewbuilder API, the following syntax should be quite familiar: 
 
-    -- create a viewbuilder 
-    local vb = renoise.ViewBuilder()
-    
-    -- create a vLib toggle button
-    local toggle_button = vToggleButton{
-      vb = vb,
-      text_enabled = "I'm enabled",
-      text_disabled = "I'm turned off",
-      width = 50,
-      height = 20,
-      notifier = function(active)
-        -- do something when clicked
-      end,
-    }
-    
-    local view = vb:row{
-      toggle_button.view -- add to view using the 'view' property 
-    }
+```lua
+-- create a viewbuilder 
+local vb = renoise.ViewBuilder()
+
+-- create a vLib toggle button
+local toggle_button = vToggleButton{
+  vb = vb,
+  text_enabled = "I'm enabled",
+  text_disabled = "I'm turned off",
+  width = 50,
+  height = 20,
+  notifier = function(active)
+    -- do something when clicked
+  end,
+}
+
+-- add to view using the 'view' property
+local view = vb:row{
+  toggle_button.view
+}
+```
 
 If you look closely, you'll notice a few minor details that are different from how the Viewbuilder API is used. 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And secondly, we are keeping a reference to the object and handing over that obj
 ## Documentation
 
 Point your browser to this location to browse the auto-generated luadocs:  
-https://renoise.github.io/luadocs/vlib
+https://renoise.github.io/libraries/vlib/index.html
 
 ## Examples 
 


### PR DESCRIPTION
Lua Documentation URL in `README.md` is pointing to a broken link.

The updated URL is now in line as per the [Renoise github home page](https://renoise.github.io/).